### PR TITLE
Use Webocket.send_binary() instead of Websocket.send()

### DIFF
--- a/novaconsole/client.py
+++ b/novaconsole/client.py
@@ -136,9 +136,9 @@ class Client (object):
             raise UserExit()
         elif self.read_escape:
             self.read_escape = False
-            self.ws.send(self.escape)
+            self.ws.send_binary(self.escape)
 
-        self.ws.send(data)
+        self.ws.send_binary(data)
 
         if data == '\r':
             self.start_of_line = True


### PR DESCRIPTION
websockify dropped support for text frames awhile back [1][2], possibly
as of version 0.9.0 [3]. Attempts to send text frames to a sufficiently
new websockify server result in the following error returned:

  Unsupported: Text frames are not supported

and then the server closes the connection.

This changes the client to call Webocket.send_binary() [4] instead of
Websocket.send() in order to send binary data rather than text.

websockify has (always?) supported receiving binary data so this should
be backward compatible with older versions.

Closes #4

[1] https://github.com/novnc/websockify/issues/365
[2] https://github.com/novnc/websockify/commit/8eb5cb0cdcd1314d6d763df8f226b587a2396aa2
[3] https://github.com/novnc/websockify/commit/8a697622495fd319582cd1c604e7eb2cc0ac0ef6
[4] https://websocket-client.readthedocs.io/en/latest/core.html#websocket._core.WebSocket.send_binary